### PR TITLE
Title is now a clickable link

### DIFF
--- a/kreedz/gokzstats.html
+++ b/kreedz/gokzstats.html
@@ -39,7 +39,7 @@
       <div class="mobile-nav">
         <img class="mobile-nav-logo" src="../Pictures/LogoSpace.png"></img>
       </div>
-      <h1 class="title">GOKZ Stats</h1>
+      <h1 class="title"><a id="title-link" href="https://gokzstats.com/">GOKZ Stats</a></h1>
     </div>
 
     <div class="modes">


### PR DESCRIPTION
The title GOKZ Stats is now a clickable link that redirects back to the main page. This is done because we no longer have the Home button that was previously removed in #20